### PR TITLE
Refactor version comparison logic in info_compare_xray function

### DIFF
--- a/_xkeen/01_info/09_info_compare/02_compare_xray.sh
+++ b/_xkeen/01_info/09_info_compare/02_compare_xray.sh
@@ -1,17 +1,22 @@
+# Функция приведения SemVer версии к числу
+padded_version() {
+    printf "%03d%03d%03d" $(echo "$1" | tr '.' ' ');
+}
+
 # Функция для сравнения версий Xray и определения статуса
 info_compare_xray() {
     # Проверяем, установлен ли Xray
     if [ -z "$xray_current_version" ]; then
         info_compare_xray="not_installed" # Если Xray не установлен, статус - не установлен
-		
+
     else
         # Сравниваем текущую версию Xray с версией из GitHub
         if [ "$xray_current_version" = "$xray_github_version" ]; then
             info_compare_xray="actual" # Если версии совпадают, Xray актуален
-			
-        elif [ "$xray_current_version" \< "$xray_github_version" ]; then
+
+        elif [ $(padded_version $xray_current_version) -lt $(padded_version $xray_github_version) ]; then
             info_compare_xray="update" # Если текущая версия меньше версии из GitHub, требуется обновление
-			
+
         else
             info_compare_xray="not_release" # Если версия из GitHub меньше текущей версии (не выпущена), Xray не выпущен
         fi


### PR DESCRIPTION
Предлагаю изменить логику сравнения версий xray.

В базовой реализации 1.8.4 не меньше 1.8.23 из-за строкового сравнения, что не является корректным результатом сравнения версий. Выяснил это, разбираясь с [попыткой обновить xray ](https://github.com/Skrill0/XKeen/issues/1)